### PR TITLE
Support handing titles in other languages (Closes: #5)

### DIFF
--- a/src/languages.h
+++ b/src/languages.h
@@ -1,0 +1,63 @@
+#include <nn/acp/title.h>
+#include <sysapp/launch.h>
+#include <sysapp/title.h>
+// Language definitions.
+// First is english: then it is in order of the ACPMetaXml struct
+// https://wut.devkitpro.org/group__nn__acp__title.html#structACPMetaXml
+#define LANG_ENGLISH             0
+#define LANG_JAPANESE            1
+#define LANG_FRENCH              2
+#define LANG_GERMAN              3
+#define LANG_ITALIAN             4
+#define LANG_SPANISH             5
+#define LANG_SIMPLIFIED_CHINESE  6
+#define LANG_KOREAN              7
+#define LANG_DUTCH               8
+#define LANG_PORTUGUESE          9
+#define LANG_RUSSIAN             10
+#define LANG_TRADITIONAL_CHINESE 11
+
+#define TITLE_LANG_DEFAULT_VALUE LANG_ENGLISH
+uint32_t titleLang = TITLE_LANG_DEFAULT_VALUE;
+
+inline char *getTitleLongname(ACPMetaXml *meta) {
+    switch (titleLang) {
+        case LANG_JAPANESE:
+            return meta->longname_ja;
+            break;
+        case LANG_FRENCH:
+            return meta->longname_fr;
+            break;
+        case LANG_GERMAN:
+            return meta->longname_de;
+            break;
+        case LANG_ITALIAN:
+            return meta->longname_it;
+            break;
+        case LANG_SPANISH:
+            return meta->longname_es;
+            break;
+        case LANG_SIMPLIFIED_CHINESE:
+            return meta->longname_zhs;
+            break;
+        case LANG_KOREAN:
+            return meta->longname_ko;
+            break;
+        case LANG_DUTCH:
+            return meta->longname_nl;
+            break;
+        case LANG_PORTUGUESE:
+            return meta->longname_pt;
+            break;
+        case LANG_RUSSIAN:
+            return meta->longname_ru;
+            break;
+        case LANG_TRADITIONAL_CHINESE:
+            return meta->longname_zht;
+            break;
+        case LANG_ENGLISH:
+        default:
+            return meta->longname_en;
+            break;
+    }
+}

--- a/src/languages.h
+++ b/src/languages.h
@@ -21,43 +21,48 @@
 uint32_t titleLang = TITLE_LANG_DEFAULT_VALUE;
 
 inline char *getTitleLongname(ACPMetaXml *meta) {
+    char *ret;
     switch (titleLang) {
         case LANG_JAPANESE:
-            return meta->longname_ja;
+            ret = meta->longname_ja;
             break;
         case LANG_FRENCH:
-            return meta->longname_fr;
+            ret = meta->longname_fr;
             break;
         case LANG_GERMAN:
-            return meta->longname_de;
+            ret = meta->longname_de;
             break;
         case LANG_ITALIAN:
-            return meta->longname_it;
+            ret = meta->longname_it;
             break;
         case LANG_SPANISH:
-            return meta->longname_es;
+            ret = meta->longname_es;
             break;
         case LANG_SIMPLIFIED_CHINESE:
-            return meta->longname_zhs;
+            ret = meta->longname_zhs;
             break;
         case LANG_KOREAN:
-            return meta->longname_ko;
+            ret = meta->longname_ko;
             break;
         case LANG_DUTCH:
-            return meta->longname_nl;
+            ret = meta->longname_nl;
             break;
         case LANG_PORTUGUESE:
-            return meta->longname_pt;
+            ret = meta->longname_pt;
             break;
         case LANG_RUSSIAN:
-            return meta->longname_ru;
+            ret = meta->longname_ru;
             break;
         case LANG_TRADITIONAL_CHINESE:
-            return meta->longname_zht;
+            ret = meta->longname_zht;
             break;
         case LANG_ENGLISH:
         default:
-            return meta->longname_en;
+            ret = meta->longname_en;
             break;
     }
+
+    // Fallback for titles which don't have a language-specific translation
+    if (ret != NULL && ret[0] == '\0') ret = meta->longname_en;
+    return ret;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "languages.h"
 #include "utils/logger.h"
 #include <coreinit/bsp.h>
 #include <coreinit/filesystem.h>
@@ -46,6 +47,7 @@ uint8_t vpad_battery = 0;
 
 #define ENABLE_SERVER_DEFAULT_VALUE true
 #define ENABLE_SERVER_CONFIG_ID     "enableServer"
+#define TITLE_LANG_CONFIG_ID        "titleLang"
 
 bool enableServer = ENABLE_SERVER_DEFAULT_VALUE;
 
@@ -185,7 +187,7 @@ void make_server() {
                 DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleMetaXml");
                 return HttpResponse{500, "text/plain", "Couldn't get the title! Error at ACPGetTitleMetaXml"};
             }
-            return HttpResponse{200, "text/plain", meta->longname_en};
+            return HttpResponse{200, "text/plain", getTitleLongname(meta)};
         });
 
         // NOT FOR HOMEBREW TITLES!!!!!!!
@@ -233,13 +235,13 @@ void make_server() {
                     if (meta.longname_en[0] != '\0') {
                         DEBUG_FUNCTION_LINE_INFO("Finished %s", meta.longname_en);
                         try {
-                            res[std::to_string(title.titleId)] = meta.longname_en;
+                            res[std::to_string(title.titleId)] = getTitleLongname(&meta);
                             DEBUG_FUNCTION_LINE_INFO("Written to JSON");
                         } catch (std::exception &e) {
                             DEBUG_FUNCTION_LINE_ERR("Failed to write title to JSON: %s\n", e.what());
                         }
                     } else {
-                        DEBUG_FUNCTION_LINE_INFO("No longname");
+                        DEBUG_FUNCTION_LINE_INFO("No English longname - not proceeding");
                     }
                 }
             }
@@ -310,14 +312,36 @@ void enableServerChanged(ConfigItemBoolean *item, bool newValue) {
     enableServer = newValue;
 }
 
+static void titleLangChanged(ConfigItemMultipleValues *item, uint32_t newValue) {
+    if (newValue != titleLang) {
+        WUPSStorageAPI::Store(TITLE_LANG_CONFIG_ID, newValue);
+    }
+    titleLang = newValue;
+}
+
 WUPSConfigAPICallbackStatus ConfigMenuOpenedCallback(WUPSConfigCategoryHandle rootHandle) {
     // To use the C++ API, we create new WUPSConfigCategory from the root handle!
     WUPSConfigCategory root = WUPSConfigCategory(rootHandle);
+
+    constexpr WUPSConfigItemMultipleValues::ValuePair titleLangMap[] = {
+            {LANG_ENGLISH, "English"},
+            {LANG_JAPANESE, "Japanese"},
+            {LANG_FRENCH, "French"},
+            {LANG_GERMAN, "German"},
+            {LANG_ITALIAN, "Italian"},
+            {LANG_SPANISH, "Spanish"},
+            {LANG_SIMPLIFIED_CHINESE, "Chinese (Simplified)"},
+            {LANG_KOREAN, "Korean"},
+            {LANG_DUTCH, "Dutch"},
+            {LANG_PORTUGUESE, "Portuguese"},
+            {LANG_RUSSIAN, "Russian"},
+            {LANG_TRADITIONAL_CHINESE, "Chinese (Traditional)"}};
 
     // The functions of the Config API come in two variants: One that throws an exception, and another one which doesn't
     // To use the Config API without exception see the example below this try/catch block.
     try {
         root.add(WUPSConfigItemBoolean::Create(ENABLE_SERVER_CONFIG_ID, "Enable Server", ENABLE_SERVER_DEFAULT_VALUE, enableServer, enableServerChanged));
+        root.add(WUPSConfigItemMultipleValues::CreateFromValue(TITLE_LANG_CONFIG_ID, "Title Language:", TITLE_LANG_DEFAULT_VALUE, titleLang, titleLangMap, titleLangChanged));
     } catch (std::exception &e) {
         DEBUG_FUNCTION_LINE_ERR("Creating config menu failed: %s", e.what());
         return WUPSCONFIG_API_CALLBACK_RESULT_ERROR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,6 +398,9 @@ INITIALIZE_PLUGIN() {
     if ((storageRes = WUPSStorageAPI::GetOrStoreDefault(ENABLE_SERVER_CONFIG_ID, enableServer, ENABLE_SERVER_DEFAULT_VALUE)) != WUPS_STORAGE_ERROR_SUCCESS) {
         DEBUG_FUNCTION_LINE_ERR("GetOrStoreDefault failed: %s (%d)", WUPSStorageAPI_GetStatusStr(storageRes), storageRes);
     }
+    if ((storageRes = WUPSStorageAPI::GetOrStoreDefault(TITLE_LANG_CONFIG_ID, titleLang, (uint32_t) TITLE_LANG_DEFAULT_VALUE)) != WUPS_STORAGE_ERROR_SUCCESS) {
+        DEBUG_FUNCTION_LINE_ERR("GetOrStoreDefault failed: %s (%d)", WUPSStorageAPI_GetStatusStr(storageRes), storageRes);
+    }
     if ((storageRes = WUPSStorageAPI::SaveStorage()) != WUPS_STORAGE_ERROR_SUCCESS) {
         DEBUG_FUNCTION_LINE_ERR("SaveStorage failed: %s (%d)", WUPSStorageAPI_GetStatusStr(storageRes), storageRes);
     }


### PR DESCRIPTION
Closes #5 

Since not all titles have entries for some of the languages, the fallback is English.