### PR TITLE
[WIP] Homebrew endpoints (Closes: #16)

### DIFF
--- a/src/aroma/Makefile
+++ b/src/aroma/Makefile
@@ -43,7 +43,7 @@ CXXFLAGS	:= $(CFLAGS) -std=c++23
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map) $(WUPSSPECS)
 
-LIBS	:= -lnotifications -lwups -lwut
+LIBS	:= -lnotifications -lrpxloader -lwups -lwut
 
 #-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 #list of directories containing libraries, this must be the top level

--- a/src/aroma/main.cpp
+++ b/src/aroma/main.cpp
@@ -1,5 +1,6 @@
 #include "../endpoints/device.h"
 #include "../endpoints/gamepad.h"
+#include "../endpoints/homebrew.h"
 #include "../endpoints/launch.h"
 #include "../endpoints/odd.h"
 #include "../endpoints/power.h"
@@ -59,6 +60,7 @@ void make_server() {
 
         registerDeviceEndpoints(server);
         registerGamepadEndpoints(server);
+        registerHomebrewEndpoints(server);
         registerLaunchEndpoints(server);
         registerODDEndpoints(server);
         registerPowerEndpoints(server);

--- a/src/aroma/main.cpp
+++ b/src/aroma/main.cpp
@@ -13,6 +13,7 @@
 #include "http.hpp"
 #include <nn/ac.h>
 #include <notifications/notifications.h>
+#include <rpxloader/rpxloader.h>
 #include <wups.h>
 #include <wups/config/WUPSConfigItemBoolean.h>
 #include <wups/config/WUPSConfigItemIntegerRange.h>
@@ -173,6 +174,9 @@ INITIALIZE_PLUGIN() {
     WHBLogCafeInit();
     WHBLogUdpInit();
     NotificationModule_InitLibrary();
+    if (RPXLoader_InitLibrary() != RPX_LOADER_RESULT_SUCCESS) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to init RPX loader");
+    }
 
     DEBUG_FUNCTION_LINE("Hello world! - Ristretto");
 
@@ -197,6 +201,7 @@ INITIALIZE_PLUGIN() {
 DEINITIALIZE_PLUGIN() {
     stop_server();
     DEBUG_FUNCTION_LINE("Ristretto deinitializing.");
+    RPXLoader_DeInitLibrary();
     NotificationModule_DeInitLibrary();
     WHBLogUdpDeinit();
     WHBLogCafeDeinit();

--- a/src/endpoints/homebrew.cpp
+++ b/src/endpoints/homebrew.cpp
@@ -1,0 +1,6 @@
+#include "homebrew.h"
+
+#include <rpxloader/rpxloader.h>
+
+void registerHomebrewEndpoints(HttpServer &server) {
+}

--- a/src/endpoints/homebrew.h
+++ b/src/endpoints/homebrew.h
@@ -1,0 +1,4 @@
+#include "../utils/logger.h"
+#include "http.hpp"
+
+void registerHomebrewEndpoints(HttpServer &server);


### PR DESCRIPTION
Closes #16 

This requires the [librpxloader](https://github.com/wiiu-env/librpxloader/) library. This will also make Ristretto require the the [RPXLoadingModule](https://github.com/wiiu-env/RPXLoadingModule).

This also requires the [libwuhbtils](https://github.com/wiiu-env/libwuhbutils/) library, and also requires Ristretto have the [WUHBUtilsModule](https://github.com/wiiu-env/WUHBUtilsModule) present.

- [ ] An endpoint getting current running homebrew application (at least the path of the RPX, then try to see if we can get WUHB data)
- [ ] An endpoint getting a list of all the homebrew applications installed (Wii U side - have configuration to include rpm homebrew and WUHB homebrew visibility)