### PR TITLE
HDMI-CEC support

### DIFF
--- a/src/aroma/main.cpp
+++ b/src/aroma/main.cpp
@@ -1,3 +1,4 @@
+#include "../endpoints/cec.h"
 #include "../endpoints/device.h"
 #include "../endpoints/gamepad.h"
 #include "../endpoints/launch.h"
@@ -11,8 +12,10 @@
 #include "../utils/logger.h"
 #include "globals.h"
 #include "http.hpp"
+#include <avm/cec.h>
 #include <nn/ac.h>
 #include <notifications/notifications.h>
+#include <tve/cec.h>
 #include <wups.h>
 #include <wups/config/WUPSConfigItemBoolean.h>
 #include <wups/config/WUPSConfigItemIntegerRange.h>
@@ -56,6 +59,7 @@ void make_server() {
             return HttpResponse{200, "text/plain", "Ristretto"};
         });
 
+        registerCECEndpoints(server);
         registerDeviceEndpoints(server);
         registerGamepadEndpoints(server);
         registerLaunchEndpoints(server);
@@ -173,6 +177,10 @@ INITIALIZE_PLUGIN() {
     WHBLogCafeInit();
     WHBLogUdpInit();
     NotificationModule_InitLibrary();
+    TVECECInit();
+    TVESetCECEnable(true);
+    AVMCECInit();
+    AVMEnableCEC();
 
     DEBUG_FUNCTION_LINE("Hello world! - Ristretto");
 

--- a/src/aroma/main.cpp
+++ b/src/aroma/main.cpp
@@ -177,10 +177,6 @@ INITIALIZE_PLUGIN() {
     WHBLogCafeInit();
     WHBLogUdpInit();
     NotificationModule_InitLibrary();
-    TVECECInit();
-    TVESetCECEnable(true);
-    AVMCECInit();
-    AVMEnableCEC();
 
     DEBUG_FUNCTION_LINE("Hello world! - Ristretto");
 
@@ -214,6 +210,10 @@ DEINITIALIZE_PLUGIN() {
 ON_APPLICATION_START() {
     nn::ac::Initialize();
     nn::ac::ConnectAsync();
+    TVECECInit();
+    TVESetCECEnable(true);
+    AVMCECInit();
+    AVMEnableCEC();
     if (!enableServer) return;
     make_server_on_thread();
 }

--- a/src/endpoints/cec.cpp
+++ b/src/endpoints/cec.cpp
@@ -1,0 +1,54 @@
+#include "device.h"
+
+#include <avm/cec.h>
+#include <tve/cec.h>
+
+void registerCECEndpoints(HttpServer &server) {
+    server.when("/tve/cec/enabled")->requested([](const HttpRequest &req) {
+        return HttpResponse{200, "text/plain", std::to_string(TVEIsCECEnable())};
+    });
+
+    server.when("/tve/cec/vol_up")->posted([](const HttpRequest &req) {
+        uint8_t params = 65;
+        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_USER_CONTROL_PRESSED, &params, 1);
+        return HttpResponse{200, "text/plain", std::to_string(b)};
+    });
+
+    server.when("/tve/cec/tvo")->posted([](const HttpRequest &req) {
+        uint8_t params = 0;
+        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_TEXT_VIEW_ON, &params, 0);
+        return HttpResponse{200, "text/plain", std::to_string(b)};
+    });
+
+    server.when("/tve/cec/reqactive")->posted([](const HttpRequest &req) {
+        // Request the physical address
+        uint8_t params = 0;
+        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_GIVE_PHYSICAL_ADDRESS, &params, 0);
+
+        // See what we got back for that address
+        TVECECLogicalAddress outInitiator;
+        TVECECOpCode outOpCode;
+        uint8_t tvAddress;
+        uint8_t outNumParams;
+        TVECECReceiveCommand(&outInitiator, &outOpCode, &tvAddress, &outNumParams);
+
+        // Request we turn on TV
+        TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_TEXT_VIEW_ON, &params, 0);
+
+        // Switch to our source
+        b = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_ACTIVE_SOURCE, &tvAddress, 1);
+
+        return HttpResponse{200, "text/plain", std::to_string(b)};
+    });
+
+    server.when("/tve/cec/latest")->requested([](const HttpRequest &req) {
+        TVECECLogicalAddress outInitiator;
+        TVECECOpCode outOpCode;
+        uint8_t outParams;
+        uint8_t outNumParams;
+
+        TVECECReceiveCommand(&outInitiator, &outOpCode, &outParams, &outNumParams);
+        std::string ret = std::format("initiator {:d} opcode {:d} outParams {:d}", (int) outInitiator, (int) outOpCode, outParams);
+        return HttpResponse{200, "text/plain", ret};
+    });
+}

--- a/src/endpoints/cec.cpp
+++ b/src/endpoints/cec.cpp
@@ -4,23 +4,28 @@
 #include <tve/cec.h>
 
 void registerCECEndpoints(HttpServer &server) {
-    server.when("/tve/cec/enabled")->requested([](const HttpRequest &req) {
+    // Returns whether CEC is enabled and running.
+    server.when("/cec/enabled")->requested([](const HttpRequest &req) {
         return HttpResponse{200, "text/plain", std::to_string(TVEIsCECEnable())};
     });
 
-    server.when("/tve/cec/vol_up")->posted([](const HttpRequest &req) {
-        uint8_t params = 65;
-        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_USER_CONTROL_PRESSED, &params, 1);
-        return HttpResponse{200, "text/plain", std::to_string(b)};
+    // Get the latest CEC request
+    server.when("/cec/latest")->requested([](const HttpRequest &req) {
+        TVECECLogicalAddress outInitiator;
+        TVECECOpCode outOpCode;
+        uint8_t outNumParams;
+        std::vector<uint8_t> outParams(100);
+
+        TVECECReceiveCommand(&outInitiator, &outOpCode, outParams.data(), &outNumParams);
+        std::string ret = std::format("initiator {:d} opcode {:d} numparams {:d}", (uint) outInitiator, (uint) outOpCode, (uint) outNumParams);
+        for (int i = 0; i < outNumParams; i++) {
+            ret.append(std::format("\n param {:d} - {:d}", i, outParams.at(i)));
+        }
+
+        return HttpResponse{200, "text/plain", ret};
     });
 
-    server.when("/tve/cec/tvo")->posted([](const HttpRequest &req) {
-        uint8_t params = 0;
-        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_TEXT_VIEW_ON, &params, 0);
-        return HttpResponse{200, "text/plain", std::to_string(b)};
-    });
-
-    server.when("/tve/cec/reqactive")->posted([](const HttpRequest &req) {
+    server.when("/cec/request_tv_active")->posted([](const HttpRequest &req) {
         // Request the physical address
         uint8_t params = 0;
         bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_GIVE_PHYSICAL_ADDRESS, &params, 0);
@@ -41,14 +46,21 @@ void registerCECEndpoints(HttpServer &server) {
         return HttpResponse{200, "text/plain", std::to_string(b)};
     });
 
-    server.when("/tve/cec/latest")->requested([](const HttpRequest &req) {
-        TVECECLogicalAddress outInitiator;
-        TVECECOpCode outOpCode;
-        uint8_t outParams;
-        uint8_t outNumParams;
+    server.when("/cec/request_tv_on")->posted([](const HttpRequest &req) {
+        uint8_t params = 0;
+        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_TEXT_VIEW_ON, &params, 0);
+        return HttpResponse{200, "text/plain", std::to_string(b)};
+    });
 
-        TVECECReceiveCommand(&outInitiator, &outOpCode, &outParams, &outNumParams);
-        std::string ret = std::format("initiator {:d} opcode {:d} outParams {:d}", (int) outInitiator, (int) outOpCode, outParams);
-        return HttpResponse{200, "text/plain", ret};
+    server.when("/cec/tv_vol_down")->posted([](const HttpRequest &req) {
+        uint8_t params = 66;
+        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_USER_CONTROL_PRESSED, &params, 1);
+        return HttpResponse{200, "text/plain", std::to_string(b)};
+    });
+
+    server.when("/cec/tv_vol_up")->posted([](const HttpRequest &req) {
+        uint8_t params = 65;
+        bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_USER_CONTROL_PRESSED, &params, 1);
+        return HttpResponse{200, "text/plain", std::to_string(b)};
     });
 }

--- a/src/endpoints/cec.h
+++ b/src/endpoints/cec.h
@@ -1,0 +1,4 @@
+#include "../utils/logger.h"
+#include "http.hpp"
+
+void registerCECEndpoints(HttpServer &server);


### PR DESCRIPTION
Closes #21 

HDMI-CEC (Consumer Electronics Control) allows for devices to communicate over HDMI.

The Wii U has code for this - it seems to have never made it out of development (It communicates that the device name is `CAFE-CATDEV`) and may need future patching to get other things to work.

While it does seem to be sometimes unreliable with when it wants to work, when it does work, I have gotten communication to work.

This PR is a draft for just CEC in general. There are two parts: the AVM (audio video manager) and TVE (TV encoder), though AVM's CEC command send/receive requests use the same TVE enums. Regardless, I have gotten things like volume up to work. **This is actually big - this allows for the Wii U to up the TV volume regardless of what TV it is assuming the TV has CEC and it is working**.

Also, if some custom standby mode functionality was ever made, there apparently are CEC opcodes and stuff for dealing with power transitions to Standby mode, but realistically we'll probably never get there because I don't think TVE can be used on the ARM/Starbuck side.

# Note
All endpoints and names are not finalized and are subject to change