### PR TITLE
Endpoints that consolidate title and device info

### DIFF
--- a/src/aroma/main.cpp
+++ b/src/aroma/main.cpp
@@ -25,6 +25,8 @@
 #include <wups/config/WUPSConfigItemStub.h>
 #include <wups/config_api.h>
 
+#include <sys/iosupport.h>
+
 /**
     Mandatory plugin information.
     If not set correctly, the loader will refuse to use the plugin.

--- a/src/endpoints/title.cpp
+++ b/src/endpoints/title.cpp
@@ -62,6 +62,33 @@ void registerTitleEndpoints(HttpServer &server) {
             DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleMetaXml");
             return HttpResponse{500, "text/plain", "Couldn't get the title! Error at ACPGetTitleMetaXml"};
         }
+        return HttpResponse{200, "text/plain", getTitleLongname(meta)};
+    });
+
+    server.when("/title/current/id")->requested([](const HttpRequest &req) {
+        ACPTitleId id;
+        ACPResult res = ACPGetTitleIdOfMainApplication(&id);
+        if (res) {
+            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleIdOfMainApplication");
+            return HttpResponse{500, "text/plain", "Couldn't get the current title! Error at ACPGetTitleIdOfMainApplication"};
+        }
+
+        return HttpResponse{200, "text/plain", std::to_string(id)};
+    });
+
+    server.when("/title/current/info")->requested([](const HttpRequest &req) {
+        ACPTitleId id;
+        ACPResult res = ACPGetTitleIdOfMainApplication(&id);
+        if (res) {
+            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleIdOfMainApplication");
+            return HttpResponse{500, "text/plain", "Couldn't get the current title! Error at ACPGetTitleIdOfMainApplication"};
+        }
+        ACPMetaXml *meta = new ACPMetaXml;
+        res              = ACPGetTitleMetaXml(id, meta);
+        if (res) {
+            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleMetaXml");
+            return HttpResponse{500, "text/plain", "Couldn't get the title! Error at ACPGetTitleMetaXml"};
+        }
 
         int handle = MCP_Open();
         if (handle < 0) {
@@ -80,16 +107,6 @@ void registerTitleEndpoints(HttpServer &server) {
         return HttpResponse{200, ret};
     });
 
-    server.when("/title/current/id")->requested([](const HttpRequest &req) {
-        ACPTitleId id;
-        ACPResult res = ACPGetTitleIdOfMainApplication(&id);
-        if (res) {
-            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleIdOfMainApplication");
-            return HttpResponse{500, "text/plain", "Couldn't get the current title! Error at ACPGetTitleIdOfMainApplication"};
-        }
-
-        return HttpResponse{200, "text/plain", std::to_string(id)};
-    });
 
     server.when("/title/current/name")->requested([](const HttpRequest &req) {
         ACPTitleId id;

--- a/src/endpoints/title.cpp
+++ b/src/endpoints/title.cpp
@@ -62,6 +62,46 @@ void registerTitleEndpoints(HttpServer &server) {
             DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleMetaXml");
             return HttpResponse{500, "text/plain", "Couldn't get the title! Error at ACPGetTitleMetaXml"};
         }
+
+        int handle = MCP_Open();
+        if (handle < 0) {
+            throw std::runtime_error{"MCP_Open() failed with error " + std::to_string(handle)};
+        }
+        MCPTitleListType type;
+        MCP_GetTitleInfo(handle, id, &type);
+
+        miniJson::Json::_object ret;
+        ret["id"]   = std::to_string(id);
+        ret["name"] = getTitleLongname(meta);
+        ret["type"] = std::to_string(type.appType);
+
+        return HttpResponse{200, ret};
+    });
+
+    server.when("/title/current/id")->requested([](const HttpRequest &req) {
+        ACPTitleId id;
+        ACPResult res = ACPGetTitleIdOfMainApplication(&id);
+        if (res) {
+            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleIdOfMainApplication");
+            return HttpResponse{500, "text/plain", "Couldn't get the current title! Error at ACPGetTitleIdOfMainApplication"};
+        }
+
+        return HttpResponse{200, "text/plain", std::to_string(id)};
+    });
+
+    server.when("/title/current/name")->requested([](const HttpRequest &req) {
+        ACPTitleId id;
+        ACPResult res = ACPGetTitleIdOfMainApplication(&id);
+        if (res) {
+            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleIdOfMainApplication");
+            return HttpResponse{500, "text/plain", "Couldn't get the current title! Error at ACPGetTitleIdOfMainApplication"};
+        }
+        ACPMetaXml *meta = new ACPMetaXml;
+        res              = ACPGetTitleMetaXml(id, meta);
+        if (res) {
+            DEBUG_FUNCTION_LINE_ERR("Error at ACPGetTitleMetaXml");
+            return HttpResponse{500, "text/plain", "Couldn't get the title! Error at ACPGetTitleMetaXml"};
+        }
         return HttpResponse{200, "text/plain", getTitleLongname(meta)};
     });
 

--- a/src/endpoints/title.cpp
+++ b/src/endpoints/title.cpp
@@ -70,6 +70,8 @@ void registerTitleEndpoints(HttpServer &server) {
         MCPTitleListType type;
         MCP_GetTitleInfo(handle, id, &type);
 
+        MCP_Close(handle);
+
         miniJson::Json::_object ret;
         ret["id"]   = std::to_string(id);
         ret["name"] = getTitleLongname(meta);
@@ -117,6 +119,8 @@ void registerTitleEndpoints(HttpServer &server) {
 
         MCP_GetTitleId(handle, &outId);
         MCP_GetTitleInfo(handle, outId, &type);
+
+        MCP_Close(handle);
 
         // Frontend/API wrapper can translate to the actual app type: https://wut.devkitpro.org/mcp_8h_source.html#l00025
         return HttpResponse{200, "text/plain", std::to_string(type.appType)};


### PR DESCRIPTION
Instead of having to make multiple requests for the same set of information, like basic device information, add endpoints that return it all in one.

New endpoints:
GET /device/info returns a json of serial id, model number, software version and hardware version

GET /title/current/id returns current title id
GET /title/current/name returns current title name
GET /title/current/info returns a json of the current title id, name, and type