### PR TITLE
Cleanup: create endpoint namespaces

### DIFF
--- a/src/endpoints/account.cpp
+++ b/src/endpoints/account.cpp
@@ -1,7 +1,8 @@
-#include "account.h"
+#include "account.hpp"
+
 #include <nn/act/client_cpp.h>
 
-void registerAccountEndpoints(HttpServer &server) {
+void AccountEndpoints::registerEndpoints(HttpServer &server) {
     server.when("/account/id")->requested([](const HttpRequest &req) {
         char accountId[nn::act::AccountIdSize];
 
@@ -16,4 +17,13 @@ void registerAccountEndpoints(HttpServer &server) {
         nn::act::PrincipalId pid = nn::act::GetPrincipalId();
         return HttpResponse{200, "text/plain", std::format("{:d}", pid)};
     });
+}
+
+void AccountEndpoints::on_application_starts() {
+    // Connections reset every time an app starts
+    nn::act::Initialize();
+}
+
+void AccountEndpoints::on_application_ends() {
+    nn::act::Finalize();
 }

--- a/src/endpoints/account.h
+++ b/src/endpoints/account.h
@@ -1,3 +1,0 @@
-#include "http.hpp"
-
-void registerAccountEndpoints(HttpServer &server);

--- a/src/endpoints/account.hpp
+++ b/src/endpoints/account.hpp
@@ -1,0 +1,8 @@
+#include "http.hpp"
+
+namespace AccountEndpoints {
+    void on_application_starts();
+    void on_application_ends();
+
+    void registerEndpoints(HttpServer &server);
+} // namespace AccountEndpoints

--- a/src/endpoints/aroma.cpp
+++ b/src/endpoints/aroma.cpp
@@ -1,13 +1,12 @@
-#include "aroma.h"
+#include "aroma.hpp"
+
 #include "../utils/logger.h"
-#include "http.hpp"
 
 #include <wups_backend/PluginContainer.h>
-#include <wups_backend/PluginData.h>
 #include <wups_backend/PluginUtils.h>
-#include <wups_backend/import_defines.h>
+#include <wups_backend/api.h>
 
-void registerAromaEndpoints(HttpServer &server) {
+void AromaEndpoints::registerEndpoints(HttpServer &server) {
     server.when("/aroma/plugins")->requested([](const HttpRequest &req) {
         PluginBackendApiErrorType err = PLUGIN_BACKEND_API_ERROR_NONE;
 
@@ -32,4 +31,12 @@ void registerAromaEndpoints(HttpServer &server) {
 
         return HttpResponse{200, res};
     });
+}
+
+void AromaEndpoints::on_initialize_plugin() {
+    WUPSBackend_InitLibrary();
+}
+
+void AromaEndpoints::on_deinitialize_plugin() {
+    WUPSBackend_DeInitLibrary();
 }

--- a/src/endpoints/aroma.h
+++ b/src/endpoints/aroma.h
@@ -1,3 +1,0 @@
-#include "http.hpp"
-
-void registerAromaEndpoints(HttpServer &server);

--- a/src/endpoints/aroma.hpp
+++ b/src/endpoints/aroma.hpp
@@ -1,0 +1,8 @@
+#include "http.hpp"
+
+namespace AromaEndpoints {
+    void on_deinitialize_plugin();
+    void on_initialize_plugin();
+
+    void registerEndpoints(HttpServer &server);
+} // namespace AromaEndpoints

--- a/src/endpoints/cec.cpp
+++ b/src/endpoints/cec.cpp
@@ -1,9 +1,9 @@
-#include "device.h"
+#include "cec.hpp"
 
 #include <avm/cec.h>
 #include <tve/cec.h>
 
-void registerCECEndpoints(HttpServer &server) {
+void CECEndpoints::registerEndpoints(HttpServer &server) {
     // Returns whether CEC is enabled and running.
     server.when("/cec/enabled")->requested([](const HttpRequest &req) {
         return HttpResponse{200, "text/plain", std::to_string(TVEIsCECEnable())};
@@ -69,4 +69,44 @@ void registerCECEndpoints(HttpServer &server) {
         bool b         = TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_USER_CONTROL_PRESSED, &params, 1);
         return HttpResponse{200, "text/plain", std::to_string(b)};
     });
+}
+
+void CECEndpoints::on_application_starts() {
+    // CEC seems to be consistent when it starts every time an application starts.
+    TVECECInit();
+    TVESetCECEnable(true);
+
+    AVMCECInit();
+    AVMEnableCEC();
+}
+
+void CECEndpoints::on_initialize_plugin() {
+    // One-Touch Play (CEC) fix attempt: The TV turns on but doesn't switch to the Wii U input.
+    //
+    // The One-Touch Play Fix needs to be here, otherwise it will try to set the input every time an application
+    // starts. There are lots of scenarios this probably isn't good.
+    //
+    // So just enable it (then it will be re-enabled) just to send that request to switch input.
+    // The TV will turn on when the console powers on (because that's the boot process)
+    // but when the Aroma plugin loads, in theory it should turn on the TV and request active source.
+    TVECECInit();
+    TVESetCECEnable(true);
+    AVMCECInit();
+    AVMEnableCEC();
+
+    uint8_t params = 0;
+    TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_GIVE_PHYSICAL_ADDRESS, &params, 0);
+
+    // See what we got back for that address
+    TVECECLogicalAddress outInitiator;
+    TVECECOpCode outOpCode;
+    uint8_t tvAddress;
+    uint8_t outNumParams;
+    TVECECReceiveCommand(&outInitiator, &outOpCode, &tvAddress, &outNumParams);
+
+    // Request we turn on TV
+    TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_TEXT_VIEW_ON, &params, 0);
+
+    // Switch to our source
+    TVECECSendCommand(TVE_CEC_DEVICE_TV, TVE_CEC_OPCODE_ACTIVE_SOURCE, &tvAddress, 1);
 }

--- a/src/endpoints/cec.h
+++ b/src/endpoints/cec.h
@@ -1,4 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-
-void registerCECEndpoints(HttpServer &server);

--- a/src/endpoints/cec.hpp
+++ b/src/endpoints/cec.hpp
@@ -1,0 +1,10 @@
+#include "http.hpp"
+
+namespace CECEndpoints {
+    // TODO: Should we also close CEC on plugin deinit or application end?
+    void on_application_starts();
+
+    void on_initialize_plugin();
+
+    void registerEndpoints(HttpServer &server);
+} // namespace CECEndpoints

--- a/src/endpoints/device.cpp
+++ b/src/endpoints/device.cpp
@@ -1,6 +1,11 @@
-#include "device.h"
+#include "device.hpp"
 
-void registerDeviceEndpoints(HttpServer &server) {
+#include "../utils/logger.h"
+
+#include <coreinit/bsp.h>
+#include <coreinit/mcp.h>
+
+void DeviceEndpoints::registerEndpoints(HttpServer &server) {
     // Returns all information from MCPSysProdSettings in JSON, along with the Cafe OS and hardware version.
     server.when("/device/info")->requested([](const HttpRequest &req) {
         int handle = MCP_Open();

--- a/src/endpoints/device.h
+++ b/src/endpoints/device.h
@@ -1,6 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <coreinit/bsp.h>
-#include <coreinit/mcp.h>
-
-void registerDeviceEndpoints(HttpServer &server);

--- a/src/endpoints/device.hpp
+++ b/src/endpoints/device.hpp
@@ -1,0 +1,5 @@
+#include "http.hpp"
+
+namespace DeviceEndpoints {
+    void registerEndpoints(HttpServer &server);
+}

--- a/src/endpoints/fp.cpp
+++ b/src/endpoints/fp.cpp
@@ -1,10 +1,8 @@
-#include "fp.h"
-#include "http.hpp"
-#include "nn/fp/fp_cpp.h"
+#include "fp.hpp"
 
-#include <nn/fp.h>
+#include <nn/fp/fp_cpp.h>
 
-void registerFPEndpoints(HttpServer &server) {
+void FPEndpoints::registerEndpoints(HttpServer &server) {
     server.when("/fp/comment")->requested([](const HttpRequest &req) {
         nn::fp::Comment myComment;
 

--- a/src/endpoints/fp.h
+++ b/src/endpoints/fp.h
@@ -1,3 +1,0 @@
-#include "http.hpp"
-
-void registerFPEndpoints(HttpServer &server);

--- a/src/endpoints/fp.hpp
+++ b/src/endpoints/fp.hpp
@@ -1,0 +1,7 @@
+#include "http.hpp"
+
+namespace FPEndpoints {
+    // TODO: on app start/end (nn::fp::Initialize)
+
+    void registerEndpoints(HttpServer &server);
+} // namespace FPEndpoints

--- a/src/endpoints/gamepad.h
+++ b/src/endpoints/gamepad.h
@@ -1,5 +1,0 @@
-#include "../plugin/globals.h"
-#include "../utils/logger.h"
-#include "http.hpp"
-
-void registerGamepadEndpoints(HttpServer &server);

--- a/src/endpoints/gamepad.hpp
+++ b/src/endpoints/gamepad.hpp
@@ -1,0 +1,5 @@
+#include "http.hpp"
+
+namespace GamepadEndpoints {
+    void registerEndpoints(HttpServer &server);
+}

--- a/src/endpoints/launch.cpp
+++ b/src/endpoints/launch.cpp
@@ -1,4 +1,12 @@
-#include "launch.h"
+#include "launch.hpp"
+
+#include "../utils/logger.h"
+
+#include <notifications/notifications.h>
+
+#include <sysapp/launch.h>
+#include <sysapp/title.h>
+
 
 inline SysAppSettingsArgs *settingsArgsFromTarget(SYSSettingsJumpToTarget target) {
     SysAppSettingsArgs *ret = new SysAppSettingsArgs;
@@ -8,7 +16,7 @@ inline SysAppSettingsArgs *settingsArgsFromTarget(SYSSettingsJumpToTarget target
     return ret;
 }
 
-void registerLaunchEndpoints(HttpServer &server) {
+void LaunchEndpoints::registerEndpoints(HttpServer &server) {
     // Launches the Wii U Menu
     server.when("/launch/menu")->posted([](const HttpRequest &req) {
         DEBUG_FUNCTION_LINE_INFO("Launching Menu.");

--- a/src/endpoints/launch.h
+++ b/src/endpoints/launch.h
@@ -1,7 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <notifications/notifications.h>
-#include <sysapp/launch.h>
-#include <sysapp/title.h>
-
-void registerLaunchEndpoints(HttpServer &server);

--- a/src/endpoints/launch.hpp
+++ b/src/endpoints/launch.hpp
@@ -1,0 +1,7 @@
+#include "http.hpp"
+
+namespace LaunchEndpoints {
+    // NotificationModule is already initialized in the main plugin
+
+    void registerEndpoints(HttpServer &server);
+} // namespace LaunchEndpoints

--- a/src/endpoints/odd.cpp
+++ b/src/endpoints/odd.cpp
@@ -1,6 +1,10 @@
-#include "odd.h"
+#include "odd.hpp"
 
-void registerODDEndpoints(HttpServer &server) {
+#include "../utils/logger.h"
+
+#include <coreinit/mcp.h>
+
+void ODDEndpoints::registerEndpoints(HttpServer &server) {
     // Returns the title ID if what is in the ODD.
     // FIXME: Only works for Wii U titles - add Wii Game support
     server.when("/odd/titleid")->requested([](const HttpRequest &req) {

--- a/src/endpoints/odd.h
+++ b/src/endpoints/odd.h
@@ -1,5 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <coreinit/mcp.h>
-
-void registerODDEndpoints(HttpServer &server);

--- a/src/endpoints/odd.hpp
+++ b/src/endpoints/odd.hpp
@@ -1,0 +1,6 @@
+#include "http.hpp"
+
+
+namespace ODDEndpoints {
+    void registerEndpoints(HttpServer &server);
+}

--- a/src/endpoints/power.cpp
+++ b/src/endpoints/power.cpp
@@ -1,6 +1,11 @@
-#include "power.h"
+#include "power.hpp"
 
-void registerPowerEndpoints(HttpServer &server) {
+#include "../utils/logger.h"
+#include <coreinit/launch.h>
+#include <sysapp/launch.h>
+
+
+void PowerEndpoints::registerEndpoints(HttpServer &server) {
     // Shuts down the console regardless of what state it currently is in.
     server.when("/power/shutdown")->posted([](const HttpRequest &req) {
         DEBUG_FUNCTION_LINE_INFO("Shutting down Wii U.");

--- a/src/endpoints/power.h
+++ b/src/endpoints/power.h
@@ -1,6 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <coreinit/launch.h>
-#include <sysapp/launch.h>
-
-void registerPowerEndpoints(HttpServer &server);

--- a/src/endpoints/power.hpp
+++ b/src/endpoints/power.hpp
@@ -1,0 +1,5 @@
+#include "http.hpp"
+
+namespace PowerEndpoints {
+    void registerEndpoints(HttpServer &server);
+}

--- a/src/endpoints/remote.cpp
+++ b/src/endpoints/remote.cpp
@@ -1,6 +1,8 @@
-#include "remote.h"
+#include "remote.hpp"
 
-void registerRemoteEndpoints(HttpServer &server) {
+#include "../plugin/globals.h"
+
+void RemoteEndpoints::registerEndpoints(HttpServer &server) {
     // To prevent potential bad behavior, only allow for specific buttons.
 
     // A - 0x8000

--- a/src/endpoints/remote.h
+++ b/src/endpoints/remote.h
@@ -1,5 +1,0 @@
-#include "../plugin/globals.h"
-#include "../utils/logger.h"
-#include "http.hpp"
-
-void registerRemoteEndpoints(HttpServer &server);

--- a/src/endpoints/remote.hpp
+++ b/src/endpoints/remote.hpp
@@ -1,0 +1,5 @@
+#include "http.hpp"
+
+namespace RemoteEndpoints {
+    void registerEndpoints(HttpServer &server);
+}

--- a/src/endpoints/sdhc.cpp
+++ b/src/endpoints/sdhc.cpp
@@ -1,7 +1,8 @@
-#include "sdhc.h"
+#include "SDHC.hpp"
+
 #include <sdutils/sdutils.h>
 
-void registerSDHCEndpoints(HttpServer &server) {
+void SDHCEndpoints::registerEndpoints(HttpServer &server) {
     server.when("/sdhc/mounted")->requested([](const HttpRequest &req) {
         bool mounted;
         SDUtils_IsSdCardMounted(&mounted);
@@ -9,4 +10,12 @@ void registerSDHCEndpoints(HttpServer &server) {
         std::string ret = std::format("{:d}", mounted);
         return HttpResponse{200, "text/plain", ret};
     });
+}
+
+void SDHCEndpoints::on_initialize_plugin() {
+    SDUtils_InitLibrary();
+}
+
+void SDHCEndpoints::on_deinitialize_plugin() {
+    SDUtils_DeInitLibrary();
 }

--- a/src/endpoints/sdhc.h
+++ b/src/endpoints/sdhc.h
@@ -1,4 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-
-void registerSDHCEndpoints(HttpServer &server);

--- a/src/endpoints/sdhc.hpp
+++ b/src/endpoints/sdhc.hpp
@@ -1,0 +1,8 @@
+#include <http.hpp>
+
+namespace SDHCEndpoints {
+    void on_deinitialize_plugin();
+    void on_initialize_plugin();
+
+    void registerEndpoints(HttpServer &server);
+}; // namespace SDHCEndpoints

--- a/src/endpoints/switch.cpp
+++ b/src/endpoints/switch.cpp
@@ -1,6 +1,11 @@
-#include "switch.h"
+#include "switch.hpp"
 
-void registerSwitchEndpoints(HttpServer &server) {
+#include "../utils/logger.h"
+
+#include <nn/acp.h>
+#include <sysapp/switch.h>
+
+void SwitchEndpoints::registerEndpoints(HttpServer &server) {
     // Switch to the current title's manual.
     //
     // This is interesting! If the title has no manual (because none exists, or like, you aren't

--- a/src/endpoints/switch.h
+++ b/src/endpoints/switch.h
@@ -1,8 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <coreinit/mcp.h>
-#include <nn/acp/title.h>
-#include <sysapp/launch.h>
-#include <sysapp/title.h>
-
-void registerSwitchEndpoints(HttpServer &server);

--- a/src/endpoints/switch.hpp
+++ b/src/endpoints/switch.hpp
@@ -1,0 +1,5 @@
+#include <http.hpp>
+
+namespace SwitchEndpoints {
+    void registerEndpoints(HttpServer &server);
+};

--- a/src/endpoints/title.cpp
+++ b/src/endpoints/title.cpp
@@ -1,5 +1,11 @@
-#include "title.h"
+#include "title.hpp"
+
 #include "../languages.h" // for access to titleLang
+
+#include "../utils/logger.h"
+
+#include <coreinit/mcp.h>
+#include <nn/acp.h>
 
 inline char *getTitleLongname(ACPMetaXml *meta) {
     char *ret;
@@ -48,7 +54,7 @@ inline char *getTitleLongname(ACPMetaXml *meta) {
     return ret;
 }
 
-void registerTitleEndpoints(HttpServer &server) {
+void TitleEndpoints::registerEndpoints(HttpServer &server) {
     server.when("/title/current")->requested([](const HttpRequest &req) {
         ACPTitleId id;
         ACPResult res = ACPGetTitleIdOfMainApplication(&id);

--- a/src/endpoints/title.h
+++ b/src/endpoints/title.h
@@ -1,6 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <coreinit/mcp.h>
-#include <nn/acp/title.h>
-
-void registerTitleEndpoints(HttpServer &server);

--- a/src/endpoints/title.hpp
+++ b/src/endpoints/title.hpp
@@ -1,0 +1,5 @@
+#include "http.hpp"
+
+namespace TitleEndpoints {
+    void registerEndpoints(HttpServer &server);
+}

--- a/src/endpoints/vwii.cpp
+++ b/src/endpoints/vwii.cpp
@@ -1,6 +1,10 @@
-#include "vwii.h"
+#include "vwii.hpp"
 
-void registervWiiEndpoints(HttpServer &server) {
+#include "../utils/logger.h"
+
+#include <nn/cmpt.h>
+
+void VWiiEndpoints::registerEndpoints(HttpServer &server) {
     // Launches the vWii System Menu (both TV and GamePad)
     server.when("/vwii/launch/menu")->posted([](const HttpRequest &req) {
         DEBUG_FUNCTION_LINE_INFO("Launching vWii Menu.");

--- a/src/endpoints/vwii.h
+++ b/src/endpoints/vwii.h
@@ -1,5 +1,0 @@
-#include "../utils/logger.h"
-#include "http.hpp"
-#include <nn/cmpt.h>
-
-void registervWiiEndpoints(HttpServer &server);

--- a/src/endpoints/vwii.hpp
+++ b/src/endpoints/vwii.hpp
@@ -1,0 +1,5 @@
+#include "http.hpp"
+
+namespace VWiiEndpoints {
+    void registerEndpoints(HttpServer &server);
+}


### PR DESCRIPTION
For readability, cleanliness, and organization, each endpoint now has its code and necessary needs in its own namespaces.