### PR TITLE
sdhc.cpp header include fix

### DIFF
--- a/src/endpoints/sdhc.cpp
+++ b/src/endpoints/sdhc.cpp
@@ -1,4 +1,4 @@
-#include "SDHC.hpp"
+#include "sdhc.hpp"
 
 #include <sdutils/sdutils.h>
 


### PR DESCRIPTION
"sdhc.hpp" include should be in lowercase to compile properly (I don't know if it matters on windows but at least in filesystems without case-ignoring it does).